### PR TITLE
Handle array params in URLs

### DIFF
--- a/Zebra_Pagination.php
+++ b/Zebra_Pagination.php
@@ -900,13 +900,13 @@ class Zebra_Pagination {
                 unset($query[$this->_properties['variable_name']]);
 
             // make sure the returned HTML is W3C compliant
-            $uri = htmlspecialchars(html_entity_decode($this->_properties['base_url']) . (!empty($query) ? '?' . http_build_query(array_map('urldecode', $query)) : ''));
+            $uri = htmlspecialchars(html_entity_decode($this->_properties['base_url']) . (!empty($query) ? '?' . http_build_query($query) : ''));
 
         }
 
         // if for whatever reason the URI is an empty string it means it should be pointing to the root ("/")
         // we can't leave this as an empty string or it will point to whatever URL is currently open in the browser
-        return $uri !== '' ? $uri : '/';
+        return $uri !== '' ? rawurldecode($uri) : '/';
 
     }
 


### PR DESCRIPTION
Hi Stefan, and thanks for your great work on this library.

I've an issue with Symfony URLs that can can contains arrays, e.g.:
`select-products?&example[family]=MyFamily&example[subfamily]=Mysubfamily&other_param=Other`

In this case, only `other_param` is preserved in pagination links, because `urldecode()` returns false on arrays (see [here](https://github.com/stefangabos/Zebra_Pagination/blob/7d9904015adeead6e788086f1ba1b12cb29c59f3/Zebra_Pagination.php#L903)).

This PR fix the issue.

Thanks.

Franck.






